### PR TITLE
Update rancher cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN set -x \
   && rm glibc-$GLIBC.apk \
   && ln -s /lib/libz.so.1 /usr/glibc-compat/lib/ \
   && ln -s /lib/libc.musl-x86_64.so.1 /usr/glibc-compat/lib \
-  && curl -fsSL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose \
+  && wget -q -O /usr/local/bin/docker-compose "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" \
   && chmod +x /usr/local/bin/docker-compose \
   && docker-compose -v
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:git
 
-RUN apk --no-cache add jq curl openssl
+RUN apk --no-cache add jq openssl
 
 ENV DOCKER_DRIVER=overlay
 
@@ -22,7 +22,7 @@ RUN set -x \
 ENV RANCHER_CLI_VERSION 0.6.3
 
 RUN set -x \
-  && curl -fsSL "https://github.com/rancher/cli/releases/download/v${RANCHER_CLI_VERSION}/rancher-linux-amd64-v${RANCHER_CLI_VERSION}.tar.xz" | tar -C / -xJ \
+  && wget -q -O- "https://github.com/rancher/cli/releases/download/v${RANCHER_CLI_VERSION}/rancher-linux-amd64-v${RANCHER_CLI_VERSION}.tar.xz" | tar -C / -xJ \
   && mv /rancher-v${RANCHER_CLI_VERSION}/rancher /usr/local/bin/ \
   && rm -rf /rancher-v${RANCHER_CLI_VERSION} \
   && rancher -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker:git
 
-RUN apk --no-cache add jq
+RUN apk --no-cache add jq 
+RUN apk add --update openssl
 
 ENV DOCKER_DRIVER=overlay
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM docker:git
 
-RUN apk --no-cache add jq 
-RUN apk add --update openssl
+RUN apk --no-cache add jq curl openssl
 
 ENV DOCKER_DRIVER=overlay
 


### PR DESCRIPTION
Apart from bumping the version of Rancher CLI to be able to handle run-time secrets for the docker containers built on the server, this PR is to amend the fact that the `docker:git` image no longer seems to install `curl` or `openssl`, therefore we've moved all file requests to `wget` and install `openssl` at the top.