### PR TITLE
chore(deps): use node 12.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.16.0-alpine
+FROM node:12.16.1-alpine
 
 ENV DOCKER_DRIVER=overlay2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM node:12.16.1-alpine
 
 ENV DOCKER_DRIVER=overlay2
 
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-    && apk --no-cache add \
+RUN apk --no-cache add \
       curl \
       git \
       jq \

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker build -t weahead/builder:latest .
+docker build --pull -t weahead/builder:latest .


### PR DESCRIPTION
Upgrade Node to 12.16.1 and Alpine to 3.11.

`docker-compose` was introduced in Alpine 3.10 so no more need for edge/testing repo.